### PR TITLE
Improve debuggability

### DIFF
--- a/src/Simple/Evaluator.php
+++ b/src/Simple/Evaluator.php
@@ -63,6 +63,9 @@ class Evaluator implements JsonRpc\Evaluator
             if ($e instanceof JsonRpc\Exception) {
                 throw $e;
             } else {
+                // Send the original exception to the error log (useful for debugging purposes)
+                error_log($e);
+                // 'Rethrow' the exception, this ensures we don't reveal too much about the implementation
                 throw new JsonRpc\Exception\Evaluation($e->getMessage(), $e->getCode());
             }
         }


### PR DESCRIPTION
Without this error_log, the stack trace of the original exception (extremely valuable) is lost.
